### PR TITLE
Exclude shopify-dev-bot from CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,6 +2,7 @@
 name: Contributor License Agreement (CLA)
 
 on:
+  workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize]
   issue_comment:
@@ -14,6 +15,7 @@ jobs:
       (github.event.issue.pull_request
         && !github.event.issue.pull_request.merged_at
         && contains(github.event.comment.body, 'signed')
+        && github.actor != 'shopify-dev-bot[bot]'
       )
       || (github.event.pull_request && !github.event.pull_request.merged)
     steps:


### PR DESCRIPTION
The shopify-dev bot is not passing the CLA check required for open source repos. There shouldn't be a CLA check for bot PRs, so updating the cla.yml file to exclude shopify-dev-bot. 

There is no easy way to test this without `workflow_dispatch:` as a trigger so adding that as well. If this doesn't work we'll have a way to test the workflow while it's still in PR 🤣 