### PR TITLE
Move shopify-dev bot check outside other conditions for CLA action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,12 +12,14 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     if: |
-      (github.event.issue.pull_request
-        && !github.event.issue.pull_request.merged_at
-        && contains(github.event.comment.body, 'signed')
-        && github.actor != 'shopify-dev-bot[bot]'
+      github.actor != 'shopify-dev-bot[bot]'
+      && (
+        (github.event.issue.pull_request
+          && !github.event.issue.pull_request.merged_at
+          && contains(github.event.comment.body, 'signed')
+        )
+        || (github.event.pull_request && !github.event.pull_request.merged)
       )
-      || (github.event.pull_request && !github.event.pull_request.merged)
     steps:
       - uses: Shopify/shopify-cla-action@v1
         with:


### PR DESCRIPTION
ok so! there was a mistake in checking the actor, we should not have grouped it with other checks. To confirm this worked, I used my sandbox repo to see if the CLA check would skip when on a github actor match. It appears to work. 

CLA.yml to test:
```
# .github/workflows/cla.yml
name: Contributor License Agreement (CLA)

on:
  workflow_dispatch:
  pull_request_target:
    types: [opened, synchronize]
  issue_comment:
    types: [created]

jobs:
  cla:
    runs-on: ubuntu-latest
    if: |
      github.actor != 'mgmanzella'
      && (
        (github.event.issue.pull_request
          && !github.event.issue.pull_request.merged_at
          && contains(github.event.comment.body, 'signed')
        )
        || (github.event.pull_request && !github.event.pull_request.merged)
      )
    steps:
      - uses: Shopify/shopify-cla-action@v1
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          cla-token: ${{ secrets.CLA_TOKEN }}
```


Test PR opened:
<img width="972" alt="Screenshot 2022-11-17 at 2 13 03 PM" src="https://user-images.githubusercontent.com/18431672/202538612-636cbc19-cc42-4df3-85a0-2df24d2ad47a.png">

(notice the CLA check is skipped 😄 )
