### PR TITLE
Add new workflow to update latest.json changes pushed to main

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -1,0 +1,26 @@
+name: Update latest.json when changes pushed to main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v2
+      - name: Write latest sha to latest.json
+        run: |
+          echo -e { \"latest\": \"$(git rev-parse HEAD)\" }\\n > latest.json
+      - name: Run git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+      - name: Commit and push changes
+        run: |
+          git add latest.json
+          git commit -m "Update latest.json"
+          git push origin main


### PR DESCRIPTION
### Summary

Part of https://github.com/Shopify/theme-liquid-docs/issues/50

When changes are pushed to main, modify the latest.json file to indicate the repo has changed. 

We're moving this logic into a Github Action from the sync docs job to keep that job as small as possible and reducing the long term maintenance cost. In a Github Action, we can leverage the git cli vs having to maintain github ruby client code (which requires manually manipulating trees when creating commits)

### Post-merge 
- [ ] Confirm that a Github Action can merge commits into main even if the branch is protected (it works in [this sandbox repo](https://github.com/Shopify/mgmanzella-sandbox) i created, main is protected but Github Actions still can write to it)
