### PR TITLE
Modifying the theme extension schema per latest design

### DIFF
--- a/schemas/update/update_extension_schema_v1.json
+++ b/schemas/update/update_extension_schema_v1.json
@@ -69,7 +69,7 @@
         "old_value": { "type": "string" },
         "new_value": { "type": "string" }
       },
-      "required": ["action", "file", "key", "new_value"],
+      "required": ["action", "file", "key", "old_value", "new_value"],
       "additionalProperties": false
     },
     "deleteStep": {
@@ -100,19 +100,27 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "additionalProperties": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "anyOf": [
-              { "$ref": "#/definitions/moveStep" },
-              { "$ref": "#/definitions/copyStep" },
-              { "$ref": "#/definitions/addStep" },
-              { "$ref": "#/definitions/updateStep" },
-              { "$ref": "#/definitions/deleteStep" }
-            ]
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "anyOf": [
+                { "$ref": "#/definitions/moveStep" },
+                { "$ref": "#/definitions/copyStep" },
+                { "$ref": "#/definitions/addStep" },
+                { "$ref": "#/definitions/updateStep" },
+                { "$ref": "#/definitions/deleteStep" }
+              ]
+            }
           }
-        }
+
+        },
+        "required": ["id", "actions"],
+        "additionalProperties": false
       }
     }
   },


### PR DESCRIPTION
Resolves https://github.com/Shopify/shopify/issues/428094
Updating the extension schema per latest [design](https://docs.google.com/document/d/1Oi8fL7vC6Pcv3egoC_QzaWPfZ39G90Sb_igff6uLUkg/edit#bookmark=kix.6er6gmsj1zot) for the static validations. 
This schema is not released yet as the feature is under build so the modification is safe to do at this point. 

PR to update the schema in Shopify Core: https://github.com/Shopify/shopify/pull/428468

(Related: Original [PR](https://github.com/Shopify/theme-liquid-docs/pull/179) where it was introduced.)