### PR TITLE
:label: Fixes all_products return type annotation

### DIFF
--- a/data/objects.json
+++ b/data/objects.json
@@ -651,7 +651,7 @@
     "examples": [
       {
         "name": "",
-        "description": "You can use `all_products` to access a product by its [handle](/docs/api/liquid/basics#handles). If the product isn't found, then `nil` is returned.",
+        "description": "You can use `all_products` to access a product by its [handle](/docs/api/liquid/basics#handles). If the product isn't found, then `empty` is returned.",
         "syntax": "",
         "path": "/",
         "raw_liquid": "{{ all_products['love-potion'].title }}",


### PR DESCRIPTION
A handle that isn't present in the list returns an `EmptyDrop` which, unlike `nil` is no falsy for some reason.