### PR TITLE
Remove the update action from theme update extension schema

### DIFF
--- a/schemas/update/update_extension_schema_v1.json
+++ b/schemas/update/update_extension_schema_v1.json
@@ -115,33 +115,6 @@
       "required": ["action", "file", "key", "value"],
       "additionalProperties": false
     },
-    "updateStep": {
-      "type": "object",
-      "properties": {
-        "action": {
-          "const": "update",
-          "description": "The action type."
-        },
-        "file": {
-          "type": "string",
-          "description": "The relative path of the file to update the key-value pair in."
-        },
-        "key": {
-          "type": "string",
-          "description": "The setting id to update."
-        },
-        "old_value": {
-          "type": "string",
-          "description": "The old setting id to be replaced."
-        },
-        "new_value": {
-          "type": "string",
-          "description": "The new setting id to replace the old one."
-        }
-      },
-      "required": ["action", "file", "key", "old_value", "new_value"],
-      "additionalProperties": false
-    },
     "deleteStep": {
       "type": "object",
       "properties": {
@@ -198,7 +171,6 @@
                 { "$ref": "#/definitions/moveStep" },
                 { "$ref": "#/definitions/copyStep" },
                 { "$ref": "#/definitions/addStep" },
-                { "$ref": "#/definitions/updateStep" },
                 { "$ref": "#/definitions/deleteStep" }
               ]
             }


### PR DESCRIPTION
Resolves https://github.com/Shopify/theme-liquid-docs/issues/227
Removing the update action API from the schema. ([context](https://docs.google.com/document/d/1kfeB1SFg9oygW_0mEHON51eB4du_2QNq5US46mEJd_A/edit#heading=h.243m6mt93xx0))