### PR TITLE
add text_alignment to settings

### DIFF
--- a/schemas/theme/section_schema.json
+++ b/schemas/theme/section_schema.json
@@ -45,6 +45,7 @@
               "select",
               "text",
               "textarea",
+              "text_alignment",
               "url",
               "video_url",
               "video"

--- a/schemas/theme/tests/section_schema.spec.ts
+++ b/schemas/theme/tests/section_schema.spec.ts
@@ -38,6 +38,7 @@ const ALLOWED_SETTING_TYPES = [
   "select",
   "text",
   "textarea",
+  "text_alignment",
   "url",
   "video_url",
   "video",


### PR DESCRIPTION
Trying to fix foward on a bug found during text_alignment launch today 

Bug: https://twitter.com/GoffeyUK/status/1704935264789909550?s=19

I just tried the text_alignment on a block within a section, and while the CLI didn't throw any errors, I wasn't able to create the block within the theme customiser. A quick look at the console, and I was seeing an error "unknown setting"

While the dev docs were posted, I dont think this validator has updated with the new setting. 