### PR TITLE
Fix validation of section schema preset settings

### DIFF
--- a/schemas/theme/section_schema.json
+++ b/schemas/theme/section_schema.json
@@ -89,7 +89,7 @@
           "required": ["id", "type", "label"]
         }
       },
-      "minItems": 1
+      "minItems": 0
     },
     "sectionToggle": {
       "type": "object",
@@ -144,7 +144,14 @@
     "tag": {
       "type": "string",
       "description": "The HTML element to use for the section.",
-      "enum": ["article", "aside", "div", "footer", "header", "section"]
+      "enum": [
+        "article",
+        "aside",
+        "div",
+        "footer",
+        "header",
+        "section"
+      ]
     },
     "class": {
       "type": "string",
@@ -214,7 +221,12 @@
             "type": "object",
             "description": "Default values for settings.",
             "additionalProperties": {
-              "type": "string"
+              "anyOf": [
+                { "type": "number" },
+                { "type": "boolean" },
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+              ]
             }
           },
           "blocks": {
@@ -231,7 +243,15 @@
                   "type": "object",
                   "description": "Block settings.",
                   "additionalProperties": {
-                    "type": "string"
+                    "anyOf": [
+                      { "type": "number" },
+                      { "type": "boolean" },
+                      { "type": "string" },
+                      {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      }
+                    ]
                   }
                 }
               },
@@ -250,7 +270,12 @@
           "type": "object",
           "description": "Default values for settings.",
           "additionalProperties": {
-            "type": "string"
+            "anyOf": [
+              { "type": "number" },
+              { "type": "boolean" },
+              { "type": "string" },
+              { "type": "array", "items": { "type": "string" } }
+            ]
           }
         },
         "blocks": {
@@ -267,7 +292,12 @@
                 "type": "object",
                 "description": "Block settings.",
                 "additionalProperties": {
-                  "type": "string"
+                  "anyOf": [
+                    { "type": "number" },
+                    { "type": "boolean" },
+                    { "type": "string" },
+                    { "type": "array", "items": { "type": "string" } }
+                  ]
                 }
               }
             },

--- a/schemas/theme/tests/section_schema.spec.ts
+++ b/schemas/theme/tests/section_schema.spec.ts
@@ -8,6 +8,8 @@ import sectionSchema1 from "../../../test/fixtures/section-schema-1.json";
 import sectionSchema2 from "../../../test/fixtures/section-schema-2.json";
 import sectionSchema3 from "../../../test/fixtures/section-schema-3.json";
 import sectionSchema4 from "../../../test/fixtures/section-schema-4.json";
+import sectionSchema5 from "../../../test/fixtures/section-schema-5.json";
+import sectionSchema6 from "../../../test/fixtures/section-schema-6.json";
 
 const emptySchema = {};
 const ALLOWED_SETTING_TYPES = [
@@ -55,6 +57,8 @@ describe("JSON Schema validation for Theme Liquid Section Schemas", () => {
     sectionSchema2,
     sectionSchema3,
     sectionSchema4,
+    sectionSchema5,
+    sectionSchema6,
   ])("should evaluate valid section schemas expectedly", (sectionSchema) => {
     const errors = validate(sectionSchema);
     expect(errors).toStrictEqual([]);
@@ -121,7 +125,7 @@ describe("JSON Schema validation for Theme Liquid Section Schemas", () => {
       },
     ]);
   });
-  
+
   it("should properly validate the max value for max_blocks", () => {
     const errors = validate({ max_blocks: 51 });
     expect(errors).toStrictEqual([

--- a/test/fixtures/section-schema-5.json
+++ b/test/fixtures/section-schema-5.json
@@ -1,0 +1,114 @@
+{
+  "name": "t:sections.announcement-bar.name",
+  "max_blocks": 12,
+  "class": "announcement-bar-section",
+  "enabled_on": {
+    "groups": ["header"]
+  },
+  "settings": [
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "t:sections.all.colors.label",
+      "default": "accent-1"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_line_separator",
+      "default": true,
+      "label": "t:sections.header.settings.show_line_separator.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.announcement-bar.settings.header__1.content",
+      "info": "t:sections.announcement-bar.settings.header__1.info"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_social",
+      "default": false,
+      "label": "t:sections.announcement-bar.settings.show_social.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.announcement-bar.settings.header__2.content"
+    },
+    {
+      "type": "checkbox",
+      "id": "auto_rotate",
+      "label": "t:sections.announcement-bar.settings.auto_rotate.label",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "change_slides_speed",
+      "min": 3,
+      "max": 10,
+      "step": 1,
+      "unit": "s",
+      "label": "t:sections.announcement-bar.settings.change_slides_speed.label",
+      "default": 5
+    },
+    {
+      "type": "header",
+      "content": "t:sections.announcement-bar.settings.header__3.content",
+      "info": "t:sections.announcement-bar.settings.header__3.info"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_country_selector",
+      "default": false,
+      "label": "t:sections.announcement-bar.settings.enable_country_selector.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.announcement-bar.settings.header__4.content",
+      "info": "t:sections.announcement-bar.settings.header__4.info"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_language_selector",
+      "default": false,
+      "label": "t:sections.announcement-bar.settings.enable_language_selector.label"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "announcement",
+      "name": "t:sections.announcement-bar.blocks.announcement.name",
+      "settings": [
+        {
+          "type": "text",
+          "id": "text",
+          "default": "Welcome to our store",
+          "label": "t:sections.announcement-bar.blocks.announcement.settings.text.label"
+        },
+        {
+          "type": "url",
+          "id": "link",
+          "label": "t:sections.announcement-bar.blocks.announcement.settings.link.label"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "t:sections.announcement-bar.presets.name",
+      "settings": {
+        "number": 1,
+        "boolean": true,
+        "string": "string"
+      },
+      "blocks": [
+        {
+          "type": "announcement",
+          "settings": {
+            "number": 1,
+            "boolean": true,
+            "string": "string"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/section-schema-6.json
+++ b/test/fixtures/section-schema-6.json
@@ -1,0 +1,63 @@
+{
+  "name": "Example Section",
+  "tag": "div",
+  "class": "example-class",
+  "limit": 1,
+  "settings": [],
+  "max_blocks": 2,
+  "blocks": [],
+  "presets": [
+    {
+      "name": "Example Preset",
+      "settings": {
+        "exampleString": "This is a string",
+        "exampleNumber": 123,
+        "exampleBoolean": true,
+        "exampleArray": ["String 1", "String 2"]
+      },
+      "blocks": [
+        {
+          "type": "exampleBlock",
+          "settings": {
+            "exampleString": "This is a string",
+            "exampleNumber": 123,
+            "exampleBoolean": true,
+            "exampleArray": ["String 1", "String 2"]
+          }
+        }
+      ]
+    }
+  ],
+  "default": {
+    "settings": {
+      "exampleString": "This is a string",
+      "exampleNumber": 123,
+      "exampleBoolean": true,
+      "exampleArray": ["String 1", "String 2"]
+    },
+    "blocks": [
+      {
+        "type": "exampleBlock",
+        "settings": {
+          "exampleString": "This is a string",
+          "exampleNumber": 123,
+          "exampleBoolean": true,
+          "exampleArray": ["String 1", "String 2"]
+        }
+      }
+    ]
+  },
+  "locales": {
+    "en": {
+      "exampleString": "This is a string"
+    }
+  },
+  "enabled_on": {
+    "templates": ["index"],
+    "groups": ["exampleGroup"]
+  },
+  "disabled_on": {
+    "templates": ["product"],
+    "groups": ["exampleGroup2"]
+  }
+}


### PR DESCRIPTION
Default can be `number | boolean | string | string[]`, so can the presets, and so can the blocks's settings. 

Fixes Shopify/theme-tools#198
Fixes Shopify/theme-tools#200
