### PR TITLE
Replace theme-code-tools with advanced-edits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @shopify/theme-code-tools
+*       @shopify/advanced-edits


### PR DESCRIPTION
The team currently has three different GitHub groups due to previous iterations of responsibilities and we're condensing them into one.