### PR TITLE
Allow theme blocks presets as hash (JSON schema validation)

### DIFF
--- a/schemas/theme/theme_block.json
+++ b/schemas/theme/theme_block.json
@@ -72,25 +72,10 @@
             "$ref": "./default_setting_values.json"
           },
           "blocks": {
-            "type": "array",
-            "description": "A list of child blocks that you might want to include.",
-            "markdownDescription": "A list of child blocks that you might want to include.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#presets)",
-            "required": ["type"],
-            "items": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "description": "The block type."
-                },
-                "settings": {
-                  "$ref": "./default_setting_values.json"
-                },
-                "blocks": {
-                  "$ref": "#/properties/presets/items/properties/blocks"
-                }
-              }
-            }
+            "oneOf": [
+              { "$ref": "#/definitions/blocks_array" },
+              { "$ref": "#/definitions/blocks_hash" }
+            ]
           }
         }
       }
@@ -118,6 +103,66 @@
       "type": "string",
       "description": "When Shopify renders a block, it's wrapped in an HTML element with the shopify-block class. You can append other classes by using the class attribute.",
       "markdownDescription": "When Shopify renders a block, it's wrapped in an HTML element with the `shopify-block` class. You can append other classes by using the class attribute.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#class)"
+    }
+  },
+  "definitions": {
+    "blocks_array": {
+      "type": "array",
+      "description": "A list of child blocks that you might want to include.",
+      "markdownDescription": "A list of child blocks that you might want to include.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#presets)",
+      "required": ["type"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "$ref": "#/definitions/base_block",
+          "id": {
+            "type": "string"
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "static": {
+                  "const": true
+                }
+              },
+              "required": ["static"]
+            },
+            "then": {
+              "required": ["id"]
+            }
+          }
+        ]
+      }
+    },
+    "blocks_hash": {
+      "type": "object",
+      "description": "A list of child blocks that you might want to include.",
+      "markdownDescription": "A list of child blocks that you might want to include.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#presets)",
+      "additionalProperties": {
+        "$ref": "#/definitions/base_block"
+      }
+    },
+    "base_block": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The block type."
+        },
+        "settings": {
+          "$ref": "./default_setting_values.json"
+        },
+        "blocks": {
+          "$ref": "#/properties/presets/items/properties/blocks"
+        },
+        "static": {
+          "type": "boolean",
+          "description": "If the block is rendered statically or not"
+        }
+      }
     }
   }
 }

--- a/tests/fixtures/theme-block-basics.json
+++ b/tests/fixtures/theme-block-basics.json
@@ -27,6 +27,11 @@
           "settings": {
             "some-setting": "some-value"
           }
+        },
+        {
+          "type": "button",
+          "static": true,
+          "id": "static-block-id1"
         }
       ]
     }

--- a/tests/fixtures/theme-blocks-presets-as-hash.json
+++ b/tests/fixtures/theme-blocks-presets-as-hash.json
@@ -1,0 +1,39 @@
+{
+    "name": "my block",
+    "blocks": [{ "type": "@app" }, { "type": "@theme" }],
+    "class": "my-class",
+    "tag": "custom-element",
+    "settings": [
+      {
+        "type": "header",
+        "content": "header name",
+        "info": "header info"
+      },
+      {
+        "type": "number",
+        "id": "number",
+        "label": "my number"
+      }
+    ],
+    "presets": [
+      {
+        "name": "preset name",
+        "settings": {
+          "number": 1
+        },
+        "blocks": {
+          "some-block-id": {
+            "type": "button"
+          },
+          "some-other-block-id": {
+            "type": "image",
+            "static": true,
+            "settings": {
+              "some-setting": "some-value"
+            }
+          }
+        }
+      }
+    ]
+  }
+  

--- a/tests/theme_block.spec.ts
+++ b/tests/theme_block.spec.ts
@@ -6,6 +6,7 @@ const themeBlock1 = loadFixture('theme-block-1.json');
 const themeBlock2 = loadFixture('theme-block-2.json');
 const themeBlockBasics = loadFixture('theme-block-basics.json');
 const themeBlockSettings = loadFixture('theme-block-settings.json');
+const themeBlocksPresetsAsHash = loadFixture('theme-blocks-presets-as-hash.json');
 const emptySchema = '{}';
 
 const validate = validateSchema();
@@ -13,7 +14,7 @@ const service = getService();
 
 describe('JSON Schema validation of Liquid theme block schema tags', () => {
   it('should validate valid block schemas', async () => {
-    const schemas = [emptySchema, themeBlock1, themeBlock2, themeBlockBasics];
+    const schemas = [emptySchema, themeBlock1, themeBlock2, themeBlockBasics, themeBlocksPresetsAsHash];
     for (const blockSchema of schemas) {
       const diagnostics = await validate('blocks/block.liquid', blockSchema);
       expect(diagnostics).toStrictEqual([]);


### PR DESCRIPTION
A part of: https://github.com/Shopify/online-store-web/issues/20097

The blocks inside of a block's presets can be either an array or a hash.

as an array:
```
presets: [
  {
    "name": "Preset 1"
    "blocks": [
      {
        "type": "button",
        "static": true,
        "id": "my-block-id1"
      }
    ]
  }
]
```

as a hash:
```
presets: [
  {
    "name": "Preset 1"
    "blocks": {
      "my-block-id1": {
        "type": "button"
        "static": true
      }
    }
  }
]
```

In this repo is defined the JSON schema that's used within theme-tools to highlight JSON formatting issues. This update to the theme blocks JSON schema covers allowing block presets as a hash. I also ended up adding the static block fields, which were already present in the section schema, but somehow were missing from the block schema.

I'll make a separate PR addressing this for section preset blocks as a hash as well. 