### PR TITLE
Miaz/schema name max length

### DIFF
--- a/schemas/theme/section.json
+++ b/schemas/theme/section.json
@@ -6,6 +6,7 @@
   "properties": {
     "name": {
       "type": "string",
+      "maxLength": 25,
       "description": "The name attribute determines the section title that is shown in the theme editor.",
       "markdownDescription": "The `name` attribute determines the section title that is shown in the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#name)"
     },

--- a/schemas/theme/section.json
+++ b/schemas/theme/section.json
@@ -111,48 +111,10 @@
             "$ref": "./default_setting_values.json"
           },
           "blocks": {
-            "type": "array",
-            "description": "Default blocks configurations to ship with this preset.",
-            "markdownDescription": "Default blocks configurations to ship with this preset.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)",
-            "items": {
-              "type": "object",
-              "required": ["type"],
-              "additionalProperties": false,
-              "properties": {
-                "static": {
-                  "type": "boolean",
-                  "description": "If the block is rendered statically or not"
-                },
-                "id": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string",
-                  "description": "The block type."
-                },
-                "settings": {
-                  "$ref": "./default_setting_values.json"
-                },
-                "blocks": {
-                  "$ref": "#/properties/presets/items/properties/blocks"
-                }
-              },
-              "allOf": [
-                {
-                  "if": {
-                    "properties": {
-                      "static": {
-                        "const": true
-                      }
-                    },
-                    "required": ["static"]
-                  },
-                  "then": {
-                    "required": ["id"]
-                  }
-                }
-              ]
-            }
+            "oneOf": [
+              { "$ref": "#/definitions/blocks_array" },
+              { "$ref": "#/definitions/blocks_hash" }
+            ]
           }
         }
       }
@@ -256,6 +218,64 @@
             "type": "string"
           },
           "uniqueItems": true
+        }
+      }
+    },
+    "blocks_array": {
+      "type": "array",
+      "description": "A list of child blocks that you might want to include.",
+      "markdownDescription": "A list of child blocks that you might want to include.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#presets)",
+      "required": ["type"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "$ref": "#/definitions/base_block",
+          "id": {
+            "type": "string"
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "static": {
+                  "const": true
+                }
+              },
+              "required": ["static"]
+            },
+            "then": {
+              "required": ["id"]
+            }
+          }
+        ]
+      }
+    },
+    "blocks_hash": {
+      "type": "object",
+      "description": "A list of child blocks that you might want to include.",
+      "markdownDescription": "A list of child blocks that you might want to include.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#presets)",
+      "additionalProperties": {
+        "$ref": "#/definitions/base_block"
+      }
+    },
+    "base_block": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The block type."
+        },
+        "settings": {
+          "$ref": "./default_setting_values.json"
+        },
+        "blocks": {
+          "$ref": "#/properties/presets/items/properties/blocks"
+        },
+        "static": {
+          "type": "boolean",
+          "description": "If the block is rendered statically or not"
         }
       }
     }

--- a/schemas/theme/theme_block.json
+++ b/schemas/theme/theme_block.json
@@ -6,6 +6,7 @@
   "properties": {
     "name": {
       "type": "string",
+      "maxLength": 25,
       "description": "The name attribute determines the block title that's shown in the theme editor.",
       "markdownDescription": "The `name` attribute determines the block title that's shown in the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#name)"
     },

--- a/tests/fixtures/section-schema-preset-blocks-as-hash.json
+++ b/tests/fixtures/section-schema-preset-blocks-as-hash.json
@@ -1,0 +1,55 @@
+{
+    "name": "Example Section",
+    "tag": "div",
+    "class": "example-class",
+    "limit": 1,
+    "settings": [],
+    "max_blocks": 2,
+    "blocks": [],
+    "presets": [
+      {
+        "name": "Example Preset",
+        "settings": {
+        },
+        "blocks": {
+          "exampleBlock": {
+            "type": "text",
+            "static": false,
+            "settings": {}
+          },
+          "exampleBlock2": {
+            "type": "text",
+            "static": true,
+            "settings": {},
+            "blocks": {
+              "nestedExampleBlock": {
+                "type": "text"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "locales": {
+      "en": {
+        "exampleString": "This is a string"
+      }
+    },
+    "enabled_on": {
+      "templates": [
+        "index"
+      ],
+      "groups": [
+        "exampleGroup"
+      ]
+    },
+    "disabled_on": {
+      "templates": [
+        "product"
+      ],
+      "groups": [
+        "exampleGroup2"
+      ]
+    }
+  }
+  

--- a/tests/section.spec.ts
+++ b/tests/section.spec.ts
@@ -9,6 +9,7 @@ const sectionSchema4 = loadFixture('section-schema-4.json');
 const sectionSchema5 = loadFixture('section-schema-5.json');
 const sectionSchema6 = loadFixture('section-schema-6.json');
 const sectionSchemaStaticBlockPreset = loadFixture('section-schema-static-block-preset.json');
+const sectionSchemaPresetBlocksAsHash = loadFixture('section-schema-preset-blocks-as-hash.json');
 const sectionSettings = loadFixture('section-settings.json');
 const sectionNestedBlocks = loadFixture('section-nested-blocks.json');
 const emptySchema = '{}';
@@ -27,6 +28,7 @@ describe('JSON Schema validation of Liquid theme section schema tags', () => {
       sectionSchema5,
       sectionSchema6,
       sectionNestedBlocks,
+      sectionSchemaPresetBlocksAsHash
     ];
     for (const sectionSchema of schemas) {
       const diagnostics = await validate('sections/section.liquid', sectionSchema);


### PR DESCRIPTION
As per the requested check:
```
When a schema name exceeds 25 characters, show an error message otherwise will encounter:  AssetCloud::AssetNotSaved: Validation failed: Invalid schema: name is too long (max 25 characters)
```

 from this [list](https://github.com/Shopify/online-store-web/issues/20097).
 
 Added a simple `maxLength` to the section and theme block JSON schemas.

Tested locally with theme-tools debug:

<img width="962" alt="image" src="https://github.com/user-attachments/assets/b7003dd0-49ba-4807-988a-b115471b3332">
