### PR TITLE
Allow block_order on preset

### DIFF
--- a/schemas/manifest_theme.json
+++ b/schemas/manifest_theme.json
@@ -13,6 +13,7 @@
     { "uri": "theme/theme_block_entry.json" },
     { "uri": "theme/targetted_block_entry.json" },
     { "uri": "theme/preset_blocks.json" },
+    { "uri": "theme/preset.json" },
     { "uri": "theme/local_block_entry.json" }
   ]
 }

--- a/schemas/theme/preset.json
+++ b/schemas/theme/preset.json
@@ -41,7 +41,7 @@
         "block_order": {
           "type": "array",
           "description": "The order of blocks in the preset.",
-          "markdownDescription": "The order of blocks in the preset.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
+          "markdownDescription": "The order of blocks in the preset."
         }
       }
     }

--- a/schemas/theme/preset.json
+++ b/schemas/theme/preset.json
@@ -11,11 +11,13 @@
   ],
   "definitions": {
     "presetWithBlocksArray": {
+      "type": "object",
+      "required": ["name"],
       "properties": {
         "name": {
           "type": "string",
-          "description": "The preset name, which will show in the Add section or block picker of the theme editor.",
-          "markdownDescription": "The preset name, which will show in the Add section or block picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
+          "description": "The preset name, which will show in the 'Add section' or 'Add block' picker of the theme editor.",
+          "markdownDescription": "The preset name, which will show in the 'Add section' or 'Add block' picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
         },
         "settings": {
           "$ref": "./default_setting_values.json"
@@ -23,14 +25,17 @@
         "blocks": {
           "$ref": "./preset_blocks.json#/definitions/blocksArray"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "presetWithBlocksHash": {
+      "type": "object",
+      "required": ["name", "blocks"],
       "properties": {
         "name": {
           "type": "string",
-          "description": "The preset name, which will show in the Add section or block picker of the theme editor.",
-          "markdownDescription": "The preset name, which will show in the Add section or block picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
+          "description": "The preset name, which will show in the 'Add section' or 'Add block' picker of the theme editor.",
+          "markdownDescription": "The preset name, which will show in the 'Add section' or 'Add block' picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
         },
         "settings": {
           "$ref": "./default_setting_values.json"
@@ -42,7 +47,8 @@
           "type": "array",
           "description": "The order of blocks in the preset.",
           "markdownDescription": "The order of blocks in the preset."
-        }
+        },
+        "additionalProperties": false
       }
     }
   }

--- a/schemas/theme/preset.json
+++ b/schemas/theme/preset.json
@@ -10,7 +10,7 @@
     }
   ],
   "definitions": {
-    "presetWithBlocksArray": {
+    "presetBase": {
       "type": "object",
       "required": ["name"],
       "properties": {
@@ -21,7 +21,19 @@
         },
         "settings": {
           "$ref": "./default_setting_values.json"
-        },
+        }
+      }
+    },
+    "presetWithBlocksArray": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/presetBase"
+        }
+      ],
+      "properties": {
+        "name": true,
+        "settings": true,
         "blocks": {
           "$ref": "./preset_blocks.json#/definitions/blocksArray"
         }
@@ -30,16 +42,15 @@
     },
     "presetWithBlocksHash": {
       "type": "object",
-      "required": ["name", "blocks"],
+      "allOf": [
+        {
+          "$ref": "#/definitions/presetBase"
+        }
+      ],
+      "required": ["blocks"],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "The preset name, which will show in the 'Add section' or 'Add block' picker of the theme editor.",
-          "markdownDescription": "The preset name, which will show in the 'Add section' or 'Add block' picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
-        },
-        "settings": {
-          "$ref": "./default_setting_values.json"
-        },
+        "name": true,
+        "settings": true,
         "blocks": {
           "$ref": "./preset_blocks.json#/definitions/blocksHash"
         },

--- a/schemas/theme/preset.json
+++ b/schemas/theme/preset.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Shopify Liquid Section or Block Preset Schema",
+  "oneOf": [
+    {
+      "$ref": "#/definitions/presetWithBlocksArray"
+    },
+    {
+      "$ref": "#/definitions/presetWithBlocksHash"
+    }
+  ],
+  "definitions": {
+    "presetWithBlocksArray": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The preset name, which will show in the Add section or block picker of the theme editor.",
+          "markdownDescription": "The preset name, which will show in the Add section or block picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
+        },
+        "settings": {
+          "$ref": "./default_setting_values.json"
+        },
+        "blocks": {
+          "$ref": "./preset_blocks.json#/definitions/blocksArray"
+        }
+      }
+    },
+    "presetWithBlocksHash": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The preset name, which will show in the Add section or block picker of the theme editor.",
+          "markdownDescription": "The preset name, which will show in the Add section or block picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
+        },
+        "settings": {
+          "$ref": "./default_setting_values.json"
+        },
+        "blocks": {
+          "$ref": "./preset_blocks.json#/definitions/blocksHash"
+        },
+        "block_order": {
+          "type": "array",
+          "description": "The order of blocks in the preset.",
+          "markdownDescription": "The order of blocks in the preset.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
+        }
+      }
+    }
+  }
+}

--- a/schemas/theme/preset_blocks.json
+++ b/schemas/theme/preset_blocks.json
@@ -42,7 +42,21 @@
       "description": "A list of child blocks that you might want to include.",
       "markdownDescription": "A list of child blocks that you might want to include.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)",
       "additionalProperties": {
-        "$ref": "#/definitions/commonBlockAttributes",
+        "allOf": [
+          {
+            "$ref": "#/definitions/commonBlockAttributes"
+          }
+        ],
+        "properties": {
+          "static": true,
+          "type": true,
+          "settings": true,
+          "blocks": true,
+          "block_order": {
+            "type": "array",
+            "description": "A unique identifier for the block."
+          }
+        },
         "additionalProperties": false
       }
     },

--- a/schemas/theme/preset_blocks.json
+++ b/schemas/theme/preset_blocks.json
@@ -54,7 +54,7 @@
           "blocks": true,
           "block_order": {
             "type": "array",
-            "description": "A unique identifier for the block."
+            "description": "The order of the blocks in the section."
           }
         },
         "additionalProperties": false

--- a/schemas/theme/preset_blocks.json
+++ b/schemas/theme/preset_blocks.json
@@ -1,14 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Shopify Liquid Preset Blocks Schema",
-  "oneOf": [
-    {
-      "$ref": "#/definitions/blocksArray"
-    },
-    {
-      "$ref": "#/definitions/blocksHash"
-    }
-  ],
   "definitions": {
     "blocksArray": {
       "type": "array",

--- a/schemas/theme/preset_blocks.json
+++ b/schemas/theme/preset_blocks.json
@@ -17,7 +17,9 @@
           "static": true,
           "type": true,
           "settings": true,
-          "blocks": true,
+          "blocks": {
+            "$ref": "#/definitions/blocksArray"
+          },
           "id": {
             "type": "string",
             "description": "A unique identifier for the block."
@@ -51,7 +53,9 @@
           "static": true,
           "type": true,
           "settings": true,
-          "blocks": true,
+          "blocks": {
+            "$ref": "#/definitions/blocksHash"
+          },
           "block_order": {
             "type": "array",
             "description": "The order of the blocks in the section."
@@ -70,9 +74,6 @@
         },
         "settings": {
           "$ref": "./default_setting_values.json"
-        },
-        "blocks": {
-          "$ref": "#"
         },
         "static": {
           "type": "boolean",

--- a/schemas/theme/section.json
+++ b/schemas/theme/section.json
@@ -100,7 +100,7 @@
       "markdownDescription": "Presets are default configurations of sections that enable users to easily add a section to a [JSON template](https://shopify.dev/docs/themes/architecture/templates/json-templates) through the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)",
       "items": {
         "$ref": "./preset.json"
-        }
+      }
     },
 
     "default": {

--- a/schemas/theme/section.json
+++ b/schemas/theme/section.json
@@ -99,22 +99,8 @@
       "description": "Presets are default configurations of sections that enable users to easily add a section to a JSON template through the theme editor.",
       "markdownDescription": "Presets are default configurations of sections that enable users to easily add a section to a [JSON template](https://shopify.dev/docs/themes/architecture/templates/json-templates) through the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)",
       "items": {
-        "type": "object",
-        "required": ["name"],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The preset name, which will show in the Add section picker of the theme editor.",
-            "markdownDescription": "The preset name, which will show in the Add section picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
-          },
-          "settings": {
-            "$ref": "./default_setting_values.json"
-          },
-          "blocks": {
-            "$ref": "./preset_blocks.json"
-          }
+        "$ref": "./preset.json"
         }
-      }
     },
 
     "default": {

--- a/schemas/theme/theme_block.json
+++ b/schemas/theme/theme_block.json
@@ -73,6 +73,11 @@
           },
           "blocks": {
             "$ref": "./preset_blocks.json"
+          },
+          "block_order": {
+            "type": "array",
+            "description": "The order of blocks in the preset.",
+            "markdownDescription": "The order of blocks in the preset.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/storefronts/themes/architecture/blocks/theme-blocks/schema#presets)"
           }
         }
       }

--- a/schemas/theme/theme_block.json
+++ b/schemas/theme/theme_block.json
@@ -73,11 +73,6 @@
           },
           "blocks": {
             "$ref": "./preset_blocks.json"
-          },
-          "block_order": {
-            "type": "array",
-            "description": "The order of blocks in the preset.",
-            "markdownDescription": "The order of blocks in the preset.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/storefronts/themes/architecture/blocks/theme-blocks/schema#presets)"
           }
         }
       }

--- a/schemas/theme/theme_block.json
+++ b/schemas/theme/theme_block.json
@@ -60,21 +60,7 @@
       "description": "Presets are default configurations of blocks that enable merchants to easily add a block to a JSON template through the theme editor.",
       "markdownDescription": "Presets are default configurations of blocks that enable merchants to easily add a block to a JSON template through the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#presets)",
       "items": {
-        "type": "object",
-        "required": ["name"],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The preset name, which displays in the Add block picker of the theme editor.",
-            "markdownDescription": "The preset name, which displays in the <strong>Add block</strong> picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#presets)"
-          },
-          "settings": {
-            "$ref": "./default_setting_values.json"
-          },
-          "blocks": {
-            "$ref": "./preset_blocks.json"
-          }
-        }
+        "$ref": "./preset.json"
       }
     },
 

--- a/tests/fixtures/section-schema-preset-blocks-as-hash.json
+++ b/tests/fixtures/section-schema-preset-blocks-as-hash.json
@@ -24,13 +24,14 @@
               "nestedExampleBlock": {
                 "type": "text"
               }
-            }
+            },
+            "block_order": ["nestedExampleBlock"]
+          },
+          "exampleBlock3": {
+            "type": "text"
           }
         },
-        "block_order": [
-          "exampleBlock",
-          "exampleBlock2"
-        ]
+        "block_order": ["exampleBlock", "exampleBlock2", "exampleBlock3"]
       }
     ],
     "locales": {

--- a/tests/fixtures/section-schema-preset-blocks-as-hash.json
+++ b/tests/fixtures/section-schema-preset-blocks-as-hash.json
@@ -26,7 +26,11 @@
               }
             }
           }
-        }
+        },
+        "block_order": [
+          "exampleBlock",
+          "exampleBlock2"
+        ]
       }
     ],
     "locales": {

--- a/tests/fixtures/theme-block-presets-as-hash.json
+++ b/tests/fixtures/theme-block-presets-as-hash.json
@@ -32,7 +32,11 @@
               "some-setting": "some-value"
             }
           }
-        }
+        },
+        "block_order": [
+          "some-block-id",
+          "some-other-block-id"
+        ]
       }
     ]
   }

--- a/tests/fixtures/theme-block-presets-as-hash.json
+++ b/tests/fixtures/theme-block-presets-as-hash.json
@@ -1,43 +1,48 @@
 {
-    "name": "my block",
-    "blocks": [{ "type": "@app" }, { "type": "@theme" }],
-    "class": "my-class",
-    "tag": "custom-element",
-    "settings": [
-      {
-        "type": "header",
-        "content": "header name",
-        "info": "header info"
+  "name": "my block",
+  "blocks": [{ "type": "@app" }, { "type": "@theme" }],
+  "class": "my-class",
+  "tag": "custom-element",
+  "settings": [
+    {
+      "type": "header",
+      "content": "header name",
+      "info": "header info"
+    },
+    {
+      "type": "number",
+      "id": "number",
+      "label": "my number"
+    }
+  ],
+  "presets": [
+    {
+      "name": "preset name",
+      "settings": {
+        "number": 1
       },
-      {
-        "type": "number",
-        "id": "number",
-        "label": "my number"
-      }
-    ],
-    "presets": [
-      {
-        "name": "preset name",
-        "settings": {
-          "number": 1
+      "blocks": {
+        "some-block-id": {
+          "type": "button"
         },
-        "blocks": {
-          "some-block-id": {
-            "type": "button"
+        "some-other-block-id": {
+          "type": "image",
+          "static": true,
+          "settings": {
+            "some-setting": "some-value"
           },
-          "some-other-block-id": {
-            "type": "image",
-            "static": true,
-            "settings": {
-              "some-setting": "some-value"
+          "blocks": {
+            "nested-block-id": {
+              "type": "text"
             }
-          }
-        },
-        "block_order": [
-          "some-block-id",
-          "some-other-block-id"
-        ]
-      }
-    ]
-  }
-  
+          },
+          "block_order": ["nested-block-id"]
+        }
+      },
+      "block_order": [
+        "some-block-id",
+        "some-other-block-id"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
When preset blocks are a hash, they require `block_order` since the order is lost (as opposed to the blocks array).

We noticed while working in theme-tools that we were getting a red highlight saying `block_order property not allowed` (or something to that effect). This is to fix that.

<img width="386" alt="property-not-allowed" src="https://github.com/user-attachments/assets/6e1da176-4c52-4de6-bcbd-c6e89332a607">


-----

🎩 

I was able to get the autocomplete for both the root and nested level blocks:
<img width="666" alt="image" src="https://github.com/user-attachments/assets/e9cdadb2-3469-4bac-8481-90c7da19095f">

<img width="576" alt="image" src="https://github.com/user-attachments/assets/0f97181b-5012-4cb6-88bf-a71efb9f1b95">


You can also tophat by opening this repo on this branch and playing with the fixtures, it should pop up the autocomplete.

-----

Additional case: nested blocks must be the same type as their parents - blocks arrays can only contain blocks that are also arrays, block hashes can only contain blocks that have block hashes

🎩 
<img width="593" alt="image" src="https://github.com/user-attachments/assets/89ffed42-c4e0-42a7-9cd7-8d061453aa16">


