### PR TITLE
Number input settings take string placeholders

### DIFF
--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -591,7 +591,7 @@
           "markdownDescription": "A setting of type `number` outputs a single number field.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/settings/input-settings#number)"
         },
         "placeholder": {
-          "type": "number",
+          "type": "string",
           "description": "A placeholder value for the input."
         },
         "default": { "type": "number" },


### PR DESCRIPTION
Fixes Shopify/cli#4933
