### PR TITLE
Allow Names on Preset Blocks

### DIFF
--- a/schemas/theme/preset_blocks.json
+++ b/schemas/theme/preset_blocks.json
@@ -16,6 +16,7 @@
         "properties": {
           "static": true,
           "type": true,
+          "name": true,
           "settings": true,
           "blocks": {
             "$ref": "#/definitions/blocksArray"
@@ -52,6 +53,7 @@
         "properties": {
           "static": true,
           "type": true,
+          "name": true,
           "settings": true,
           "blocks": {
             "$ref": "#/definitions/blocksHash"
@@ -71,6 +73,10 @@
         "type": {
           "type": "string",
           "description": "The block type."
+        },
+        "name": {
+          "type": "string",
+          "description": "The block name."
         },
         "settings": {
           "$ref": "./default_setting_values.json"

--- a/tests/fixtures/section-nested-blocks.json
+++ b/tests/fixtures/section-nested-blocks.json
@@ -9,7 +9,7 @@
           "type": "group",
           "blocks": [
             { "type": "text", "settings": { "text": "Hello" } },
-            { "type": "header", "settings": { "text": "World" } }
+            { "type": "header", "name": "Header", "settings": { "text": "World" } }
           ]
         }
       ]

--- a/tests/fixtures/section-schema-preset-blocks-as-hash.json
+++ b/tests/fixtures/section-schema-preset-blocks-as-hash.json
@@ -14,6 +14,7 @@
         "blocks": {
           "exampleBlock": {
             "type": "text",
+            "name": "Example Block",
             "settings": {}
           },
           "exampleBlock2": {

--- a/tests/fixtures/theme-block-basics.json
+++ b/tests/fixtures/theme-block-basics.json
@@ -24,9 +24,17 @@
       "blocks": [
         {
           "type": "thing",
+          "name": "The Thing",
           "settings": {
             "some-setting": "some-value"
-          }
+          },
+          "blocks": [
+            {
+              "type": "text",
+              "name": "Nested Text Block",
+              "settings": {}
+            }
+          ]
         },
         {
           "type": "button",

--- a/tests/fixtures/theme-block-presets-as-hash.json
+++ b/tests/fixtures/theme-block-presets-as-hash.json
@@ -27,13 +27,15 @@
         },
         "some-other-block-id": {
           "type": "image",
+          "name": "Image Block",
           "static": true,
           "settings": {
             "some-setting": "some-value"
           },
           "blocks": {
             "nested-block-id": {
-              "type": "text"
+              "type": "text",
+              "name": "Nested Text Block"
             }
           },
           "block_order": ["nested-block-id"]


### PR DESCRIPTION
As part of the Theme Blocks "Preset Name Passing" subproject, we can now put `name` on any section or block preset nested block and set it a string value. 

[Some examples](https://docs.google.com/document/d/1ne66LCdmFbR8W0gSPshvI4RhBit4h4OFMCw4ufWxRTU/edit?tab=t.0#heading=h.q9erahninhcl)
[The feature tech doc](https://docs.google.com/document/d/1zxKLyf8tOQowvU21ZdvfO3q1re29mamUm01x0WV86M0/edit?tab=t.0#heading=h.6hc05maxq8mo)
[Slack channel](https://shopify.enterprise.slack.com/archives/C087GRB2AP4)