### PR TITLE
Allow visible_if on more valid settings types

### DIFF
--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -629,7 +629,10 @@
       "additionalProperties": false
     },
     "number": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "number",
@@ -643,7 +646,8 @@
         "default": { "type": "number" },
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
@@ -701,7 +705,10 @@
     },
 
     "radio": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "radio",
@@ -715,7 +722,8 @@
         "options": { "$ref": "#/definitions/options" },
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "required": ["options"],
       "additionalProperties": false
@@ -841,7 +849,10 @@
     },
 
     "style.layout_panel": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "style.layout_panel",
@@ -866,13 +877,17 @@
         },
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "style.size_panel": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "style.size_panel",
@@ -897,13 +912,17 @@
         },
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "style.spacing_panel": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "style.spacing_panel",
@@ -928,13 +947,17 @@
         },
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "text": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "text",
@@ -950,7 +973,8 @@
         },
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
@@ -979,7 +1003,10 @@
     },
 
     "textarea": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "textarea",
@@ -995,7 +1022,8 @@
         },
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },

--- a/tests/section.spec.ts
+++ b/tests/section.spec.ts
@@ -1,10 +1,6 @@
 import set from 'lodash.set';
 import { assert, describe, expect, it } from 'vitest';
-import {
-  INPUT_SETTING_TYPES,
-  SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF,
-  SIDEBAR_SETTING_TYPES,
-} from './test-constants';
+import { INPUT_SETTING_TYPES, SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF } from './test-constants';
 import { complete, getService, hover, loadFixture, validateSchema } from './test-helpers';
 
 const sectionSchema1 = loadFixture('section-schema-1.json');
@@ -222,32 +218,33 @@ describe('JSON Schema validation of Liquid theme section schema tags', () => {
     expect(diagnostics).toStrictEqual([]);
   });
 
-  it.each(
-    INPUT_SETTING_TYPES.filter(
-      (settingType) =>
-        !SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF.concat('color_scheme_group').includes(
-          settingType,
-        ),
-    ),
-  )('should allow visible_if on %s setting type', async (settingType) => {
-    const schema = {
-      settings: [
-        {
-          type: settingType,
-          id: 'test_setting',
-          label: 'Test Setting',
-          visible_if: '{{ section.settings.some_setting }}',
-        },
-      ],
-    };
+  const settingsTypesSupportingVisibleIf = INPUT_SETTING_TYPES.filter(
+    (settingType) =>
+      !SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF.concat('color_scheme_group').includes(settingType),
+  );
 
-    const diagnostics = await validate('sections/section.liquid', schema);
-    expect(diagnostics).not.toContainEqual(
-      expect.objectContaining({
-        message: 'Property visible_if is not allowed.',
-      }),
-    );
-  });
+  it.each(settingsTypesSupportingVisibleIf)(
+    'should allow visible_if on %s setting type',
+    async (settingType) => {
+      const schema = {
+        settings: [
+          {
+            type: settingType,
+            id: 'test_setting',
+            label: 'Test Setting',
+            visible_if: '{{ section.settings.some_setting }}',
+          },
+        ],
+      };
+
+      const diagnostics = await validate('sections/section.liquid', schema);
+      expect(diagnostics).not.toContainEqual(
+        expect.objectContaining({
+          message: 'Property visible_if is not allowed.',
+        }),
+      );
+    },
+  );
 
   it.each(SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF)(
     'should not allow visible_if on %s setting type',

--- a/tests/section.spec.ts
+++ b/tests/section.spec.ts
@@ -1,6 +1,10 @@
 import set from 'lodash.set';
 import { assert, describe, expect, it } from 'vitest';
-import { SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF } from './test-constants';
+import {
+  INPUT_SETTING_TYPES,
+  SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF,
+  SIDEBAR_SETTING_TYPES,
+} from './test-constants';
 import { complete, getService, hover, loadFixture, validateSchema } from './test-helpers';
 
 const sectionSchema1 = loadFixture('section-schema-1.json');
@@ -29,7 +33,7 @@ describe('JSON Schema validation of Liquid theme section schema tags', () => {
       sectionSchema5,
       sectionSchema6,
       sectionNestedBlocks,
-      sectionSchemaPresetBlocksAsHash
+      sectionSchemaPresetBlocksAsHash,
     ];
     for (const sectionSchema of schemas) {
       const diagnostics = await validate('sections/section.liquid', sectionSchema);
@@ -211,31 +215,63 @@ describe('JSON Schema validation of Liquid theme section schema tags', () => {
   });
 
   it('should validate section schema with conditional settings', async () => {
-    const sectionSchemaConditionalSettings = loadFixture('section-schema-conditional-settings.json');
+    const sectionSchemaConditionalSettings = loadFixture(
+      'section-schema-conditional-settings.json',
+    );
     const diagnostics = await validate('sections/section.liquid', sectionSchemaConditionalSettings);
     expect(diagnostics).toStrictEqual([]);
   });
 
-  it.each(SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF)('should not allow visible_if on %s setting type', async (settingType) => {
+  it.each(
+    INPUT_SETTING_TYPES.filter(
+      (settingType) =>
+        !SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF.concat('color_scheme_group').includes(
+          settingType,
+        ),
+    ),
+  )('should allow visible_if on %s setting type', async (settingType) => {
     const schema = {
       settings: [
         {
           type: settingType,
           id: 'test_setting',
           label: 'Test Setting',
-          visible_if: '{{ section.settings.some_setting }}'
-        }
-      ]
+          visible_if: '{{ section.settings.some_setting }}',
+        },
+      ],
     };
-    
+
     const diagnostics = await validate('sections/section.liquid', schema);
-    expect(diagnostics).toContainEqual(
+    expect(diagnostics).not.toContainEqual(
       expect.objectContaining({
         message: 'Property visible_if is not allowed.',
-        severity: 1
-      })
+      }),
     );
   });
+
+  it.each(SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF)(
+    'should not allow visible_if on %s setting type',
+    async (settingType) => {
+      const schema = {
+        settings: [
+          {
+            type: settingType,
+            id: 'test_setting',
+            label: 'Test Setting',
+            visible_if: '{{ section.settings.some_setting }}',
+          },
+        ],
+      };
+
+      const diagnostics = await validate('sections/section.liquid', schema);
+      expect(diagnostics).toContainEqual(
+        expect.objectContaining({
+          message: 'Property visible_if is not allowed.',
+          severity: 1,
+        }),
+      );
+    },
+  );
 
   it('should complete the type property with the generic docs', async () => {
     const result = await complete(


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify/issues/585714

Added a test to check input types that _aren't_ forbidden allow `visible_if`, which showed several input types seemed to be missing the property.