### PR TITLE
Allow 'category' on presets

### DIFF
--- a/schemas/theme/preset.json
+++ b/schemas/theme/preset.json
@@ -19,6 +19,11 @@
           "description": "The preset name, which will show in the 'Add section' or 'Add block' picker of the theme editor.",
           "markdownDescription": "The preset name, which will show in the 'Add section' or 'Add block' picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
         },
+        "category": {
+          "type": "string",
+          "description": "The category of the preset, which will show in the 'Add section' or 'Add block' picker of the theme editor.",
+          "markdownDescription": "The category of the preset, which will show in the 'Add section' or 'Add block' picker of the theme editor.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/sections/section-schema#presets)"
+        },
         "settings": {
           "$ref": "./default_setting_values.json"
         }
@@ -33,6 +38,7 @@
       ],
       "properties": {
         "name": true,
+        "category": true,
         "settings": true,
         "blocks": {
           "$ref": "./preset_blocks.json#/definitions/blocksArray"

--- a/tests/fixtures/section-schema-1.json
+++ b/tests/fixtures/section-schema-1.json
@@ -72,6 +72,7 @@
   "presets": [
     {
       "name": "t:sections.announcement-bar.presets.name",
+      "category": "t:sections.announcement-bar.presets.category",
       "blocks": [
         {
           "type": "announcement"

--- a/tests/fixtures/theme-block-basics.json
+++ b/tests/fixtures/theme-block-basics.json
@@ -18,6 +18,7 @@
   "presets": [
     {
       "name": "preset name",
+      "category": "The Category",
       "settings": {
         "number": 1
       },


### PR DESCRIPTION
This removes the squiggly that warns that `category` is not allowed as an attribute on the preset, because it is now valid for both section and block presets.