### PR TITLE
CI must pass even when resources are updated

### DIFF
--- a/.github/workflows/update-latest-ai-file.yml
+++ b/.github/workflows/update-latest-ai-file.yml
@@ -33,5 +33,9 @@ jobs:
       - name: Commit and push changes
         run: |
           git add ai/liquid.mdc
-          git commit -m "Update ai/liquid.mdc"
-          git push origin main
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git commit -m "Update ai/liquid.mdc"
+            git push origin main
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -22,5 +22,9 @@ jobs:
       - name: Commit and push changes
         run: |
           git add data/latest.json
-          git commit -m "Update data/latest.json"
-          git push origin main
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git commit -m "Update data/latest.json"
+            git push origin main
+          else
+            echo "No changes to commit"
+          fi

--- a/ai/sources/_css.md
+++ b/ai/sources/_css.md
@@ -10,7 +10,7 @@
 
 <variables>
   - Use CSS variables to reduce redundancy
-  - Hardcode values as variables first (e.g. --touch-target-size: 44px)
+  - Hardcode values as variables first (e.g. --touch-target-size: 45px)
   - Never hardcode colors, use color schemes
   - Scope variables to components unless global
   - Global variables go in :root (in may live in a file like snippets/theme-styles-variables.liquid)


### PR DESCRIPTION
Currently, we encounter a CI error when the `data/latest.json` and `ai/liquid.mdc` files are up-to-date.

This PR updates both workflows to resolve this issue.

Here's the error we currently receive when these files are up-to-date:

![image](https://github.com/user-attachments/assets/6cbf1493-39bd-419c-8bd9-b9362dd29946)
