### PR TITLE
Pluralized html translations are valid

### DIFF
--- a/schemas/theme/translations.json
+++ b/schemas/theme/translations.json
@@ -16,8 +16,15 @@
   },
   "patternProperties": {
     ".*_html$": {
-      "type": "string",
-      "description": "Translation string that contains HTML. The '_html' suffix prevents the HTML content from being escaped."
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A string that can contain HTML content, typically used for translations that include HTML tags."
+        },
+        {
+          "$ref": "#/definitions/pluralizedString"
+        }
+      ]
     }
   },
   "definitions": {

--- a/tests/fixtures/translations-1.json
+++ b/tests/fixtures/translations-1.json
@@ -5,6 +5,10 @@
     "pluralized": {
       "one": "{{ count }} thing",
       "other": "{{ count }} things"
+    },
+    "pluralized_html": {
+      "one": "<script>console.log</script> {{ count }} thing",
+      "other": "<script>console.log</script> {{ count }} things"
     }
   }
 }


### PR DESCRIPTION
Fixes Shopify/theme-tools#798
