### PR TITLE
conditional settings supports resources

### DIFF
--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -196,7 +196,10 @@
 
   "definitions": {
     "article": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "article",
@@ -206,13 +209,17 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "blog": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "blog",
@@ -222,7 +229,8 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
@@ -248,7 +256,10 @@
     },
 
     "collection": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "collection",
@@ -258,13 +269,17 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "collection_list": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "collection_list",
@@ -278,7 +293,8 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
@@ -674,7 +690,10 @@
     },
 
     "product": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "product",
@@ -684,13 +703,17 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "product_list": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "product_list",
@@ -704,7 +727,8 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },

--- a/tests/test-constants.ts
+++ b/tests/test-constants.ts
@@ -1,13 +1,7 @@
 export const SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF = [
-  'article',
-  'blog',
-  'collection',
-  'collection_list',
   'metaobject',
   'metaobject_list',
   'page',
-  'product',
-  'product_list',
   // Not featured here is `color_scheme_group` which is exclusive to settings_schema.json.
   // That setting type is tested in `color_scheme_group.spec.ts`.
 ];


### PR DESCRIPTION
### TL;DR

Added conditional visibility support to article, blog, collection, collection_list, product, and product_list setting types.

### What changed?

- Updated the JSON schema to add support for the `visible_if` property to six setting types:
  - article
  - blog
  - collection
  - collection_list
  - product
  - product_list
- Added the `conditionalSetting` reference to the `allOf` array for each of these setting types
- Removed these setting types from the `SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF` array in test constants

### How to test?

1. Create theme settings that use these setting types with conditional visibility rules
2. Verify that the settings show/hide based on the conditions specified in `visible_if`
3. Run the existing test suite to ensure all tests pass with the updated schema

### Why make this change?

unblocks https://github.com/Shopify/horizon/pull/5053 we need to conditionally show resource settings to improve the merchant editing experience in Horizon