### PR TITLE
update fixture and add ref for conditional setting

### DIFF
--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -1126,7 +1126,10 @@
     },
 
     "paragraph": {
-      "allOf": [{ "$ref": "#/definitions/sidebarStandardSettings" }],
+      "allOf": [
+        { "$ref": "#/definitions/sidebarStandardSettings" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "paragraph",

--- a/tests/fixtures/section-schema-conditional-settings.json
+++ b/tests/fixtures/section-schema-conditional-settings.json
@@ -8,6 +8,11 @@
       "info": "Configure advanced options below"
     },
     {
+      "type": "paragraph",
+      "content": "This paragraph provides additional context and instructions for the advanced settings section.",
+      "visible_if": "{{ section.settings.show_advanced }}"
+    },
+    {
       "type": "checkbox",
       "id": "enable_features",
       "label": "Enable features",
@@ -137,4 +142,4 @@
       "visible_if": "{{ section.settings.media_type == 'video' }}"
     }
   ]
-} 
+}


### PR DESCRIPTION
### TL;DR

Added conditional visibility support to paragraph settings in theme schema.

### What changed?

- Extended the paragraph setting schema to include the `conditionalSetting` reference, allowing paragraph elements to use the `visible_if` property
- Updated the test fixture to include an example of a paragraph with conditional visibility based on a checkbox state

### How to test?

fixture passing:

![Screenshot 2025-07-09 at 12.13.51 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vIaAqbh3Um5IJRCLPJa3/67abca7e-011d-4d20-bb59-a6d574ee4675.png)



### Why make this change?

make visible_if a valid property on paragraph



