### PR TITLE
GH workflow needs to be manually triggered to update latest.json revision

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -2,9 +2,6 @@ name: Update 'ai/liquid.mdc' and 'data/latest.json' files
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   build:
@@ -29,17 +26,36 @@ jobs:
       - name: Generate AI file
         run: yarn generate:ai
 
-      - name: Run git config
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-
-      - name: Commit and push changes
+      - name: Create Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then
-            git add .
+            # Configure git
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            
+            # Create and switch to new branch
+            BRANCH_NAME="update-ai-docs-$(date +%Y%m%d-%H%M%S)"
+            git checkout -b "$BRANCH_NAME"
+            
+            # Commit changes
+            git add ai/liquid.mdc
+            git add data/latest.json
             git commit -m "Update 'ai/liquid.mdc' and 'data/latest.json' files"
-            git push origin main
+            
+            # Push branch
+            git push origin "$BRANCH_NAME"
+            
+            # Create pull request using GitHub CLI
+            gh pr create \
+              --title "Update 'ai/liquid.mdc' and 'data/latest.json' files" \
+              --body "Automated update of AI documentation and latest revision data.
+
+            - Updated \`ai/liquid.mdc\` with latest documentation
+            - Updated \`data/latest.json\` with current revision SHA" \
+              --base main \
+              --head "$BRANCH_NAME"
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
### TL;DR

Changed the GitHub workflow to create pull requests for AI documentation updates instead of directly pushing to main.

### What changed?

- Modified the `update-latest.yml` workflow to create a pull request for changes instead of pushing directly to main
- Added branch creation with timestamp-based naming (`update-ai-docs-YYYYMMDD-HHMMSS`)
- Configured the workflow to use GitHub CLI to create a pull request with a descriptive title and body
- Updated the git configuration to use the standard GitHub Actions bot identity

### How to test?

1. Trigger the workflow manually or wait for its scheduled run
2. Verify that a new pull request is created when there are changes to the AI documentation
3. Confirm the PR contains the expected changes to `ai/liquid.mdc` and `data/latest.json`
4. Check that the PR has the correct title and description

Example run: https://github.com/Shopify/theme-liquid-docs/actions/runs/16679895368/job/47215746922
Example PR created: https://github.com/Shopify/theme-liquid-docs/pull/1023
⚠️  NOTE: It also contains the file in this PR since it branches off of main. You can ignore this commit in that PR, only see the changes to `ai/liquid.mdc` and `data/latest.json`

### Why make this change?

This change improves the workflow by creating pull requests instead of direct commits to main, which:
- Provides better visibility into documentation updates
- Allows for review before changes are merged
- Creates a clearer history of documentation updates
- Follows best practices for repository management by avoiding direct pushes to the main branch