### PR TITLE
Fix visible_if support for resource-based settings

### DIFF
--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -196,7 +196,10 @@
 
   "definitions": {
     "article": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "article",
@@ -206,13 +209,17 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "blog": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "blog",
@@ -222,7 +229,8 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
@@ -248,7 +256,10 @@
     },
 
     "collection": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "collection",
@@ -258,13 +269,17 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "collection_list": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "collection_list",
@@ -278,7 +293,8 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
@@ -589,7 +605,10 @@
     },
 
     "metaobject": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "metaobject",
@@ -603,14 +622,18 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "required": ["metaobject_type"],
       "additionalProperties": false
     },
 
     "metaobject_list": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "metaobject_list",
@@ -628,7 +651,8 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "required": ["metaobject_type"],
       "additionalProperties": false
@@ -658,7 +682,10 @@
     },
 
     "page": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "page",
@@ -668,13 +695,17 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "product": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "product",
@@ -684,13 +715,17 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },
 
     "product_list": {
-      "allOf": [{ "$ref": "#/definitions/inputSettingsStandardAttributes" }],
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
       "properties": {
         "type": {
           "const": "product_list",
@@ -704,7 +739,8 @@
         "default": true,
         "label": true,
         "info": true,
-        "id": true
+        "id": true,
+        "visible_if": true
       },
       "additionalProperties": false
     },

--- a/tests/test-constants.ts
+++ b/tests/test-constants.ts
@@ -1,13 +1,4 @@
 export const SETTINGS_TYPES_NOT_SUPPORTING_VISIBLE_IF = [
-  'article',
-  'blog',
-  'collection',
-  'collection_list',
-  'metaobject',
-  'metaobject_list',
-  'page',
-  'product',
-  'product_list',
   // Not featured here is `color_scheme_group` which is exclusive to settings_schema.json.
   // That setting type is tested in `color_scheme_group.spec.ts`.
 ];


### PR DESCRIPTION
## Problem
The schema validation incorrectly flagged `visible_if` as not allowed on resource-based settings (article, blog, collection, collection_list, metaobject, metaobject_list, page, product, product_list), causing the CLI to show "Property visible_if is not allowed" errors. However, these settings actually do support `visible_if` and function correctly when used in Shopify themes.

This may have prevented developers from using this functionality where valid as working code was being flagged as invalid by the tooling.

## Solution
Updated all resource-based settings to support `visible_if` by:
- Adding `conditionalSetting` reference to their schema definitions
- Adding `visible_if: true` to their properties  
- Updated test constants to reflect the correct behaviour
- All tests pass

## Testing
Verified that `visible_if` works correctly on all resource-based settings in actual Shopify themes.