### PR TITLE
Theme blocks are no longer in dev preview

### DIFF
--- a/schemas/theme/targetted_block_entry.json
+++ b/schemas/theme/targetted_block_entry.json
@@ -8,8 +8,8 @@
     "type": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9_-]+$",
-      "description": "Developer preview: The name of a theme block found in the blocks/ folder of the theme.",
-      "markdownDescription": "🔮 **Developer preview**: The name of a theme block found in the `blocks/` folder of the theme.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#blocks)"
+      "description": "The name of a theme block found in the blocks/ folder of the theme.",
+      "markdownDescription": "The name of a theme block found in the `blocks/` folder of the theme.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#blocks)"
     }
   }
 }

--- a/schemas/theme/theme_block_entry.json
+++ b/schemas/theme/theme_block_entry.json
@@ -7,8 +7,8 @@
   "properties": {
     "type": {
       "const": "@theme",
-      "description": "Developer preview: The \"@theme\" type denotes that this container accepts theme blocks that live in the blocks/ folder of the theme.",
-      "markdownDescription": "🔮 **Developer preview**: The `@theme` type denotes that this container accepts theme blocks that live in the `blocks/` folder of the theme.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#blocks)"
+      "description": "The \"@theme\" type denotes that this container accepts theme blocks that live in the blocks/ folder of the theme.",
+      "markdownDescription": "The `@theme` type denotes that this container accepts theme blocks that live in the `blocks/` folder of the theme.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/blocks/theme-blocks/schema#blocks)"
     }
   }
 }


### PR DESCRIPTION
Theme blocks are no longer in dev preview:

<img width="1102" height="166" alt="image" src="https://github.com/user-attachments/assets/a9e67ae7-e8ef-43d4-9799-b6c4023cf297" />
