### PR TITLE
Update step size of range settings

### DIFF
--- a/ai/liquid.mdc
+++ b/ai/liquid.mdc
@@ -352,7 +352,6 @@ alwaysApply: true
     theme_assets = {
       - Contains static files such as CSS, JavaScript, and images referenced via asset_url filter
       - Includes compiled stylesheets, JavaScript bundles, and media files
-      - Can be organized in subdirectories for better file management
       - Supports asset optimization and minification for performance
       - Images should be optimized and include responsive variants when possible
       - Examples: theme.css, theme.js, logo.png, icon sprites

--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -758,6 +758,7 @@
         },
         "step": {
           "type": "number",
+          "multipleOf": 0.1,
           "description": "The increment size between steps of the slider"
         },
         "unit": {


### PR DESCRIPTION
Theme check was not catching errors in schema where a `range` step size has more than 1 decimal place.

```
    {
      "type": "range",
      "id": "font_size",
      "label": "Font Size",
      "min": 12,
      "max": 100,
      "step": 1.14, # bad!!!
      "default": 16
    },
```

This change ensures that you can only have 1 decimal place as suggested by the error we get when we save the file using the OS editor:

<img width="888" height="164" alt="image" src="https://github.com/user-attachments/assets/9bfb3041-47f8-452f-8e0f-26c78c344c98" />

### Tophat

- Go to json validator https://www.jsonschemavalidator.net/
- Add the `setting.json` file to the schema
- Create a fake "range" setting with bad step size (as seen below)

<img width="1551" height="764" alt="image" src="https://github.com/user-attachments/assets/575ab673-6745-4487-9227-b4de4232dacc" />

--

The liquid.mdc update was due to someone forgetting to run `npm run generate:ai`.
