### PR TITLE
Update README to update revision number

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,19 @@ yarn install
 
 ### Available data
 
-In `.liquid` templates, you have access to:
+In `data/`, you have access to:
 - `filters` — All available Liquid filters
 - `tags` — All Liquid tags
 - `objects` — All Liquid objects
+- `latest.json` — Identifies the version of Liquid data used by CLI, theme-tools, and other dependent projects. See [Updating revision number](#updating-revision-number) for details.
 
-Check `ai/sources/_liquid-rules.liquid` for examples.
+Check `ai/liquid.mdc` for examples.
+
+### Updating revision number
+
+Run the [GitHub Action](https://github.com/Shopify/theme-liquid-docs/actions/workflows/update-latest.yml) to update the Liquid docs used by all dependent projects.
+
+🚨 IF YOU DONT RUN THIS ACTION, DEPENDENT PROJECTS WILL USE LIQUID DOCS IDENTIFIED BY THE REVISION ID IN `data/latest.json`.
 
 ## Contributing
 


### PR DESCRIPTION
Originally, the the latest.json file was updated automatically by pushing to main.

We initially wanted to move from pushing directly to main to creating a PR when anything was merged on main, but this ended up creating a chain of never-ending PRs every time the revision ID was merged.

We will at least update README to notify that we need to run the GH Action when we want to release our latest Liquid docs.

Original discussion: https://github.com/Shopify/theme-liquid-docs/pull/1004#pullrequestreview-3028533711