### PR TITLE
Add color_palette setting type

### DIFF
--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -14,9 +14,9 @@
         "collection_list",
         "color",
         "color_background",
+        "color_palette",
         "color_scheme",
         "color_scheme_group",
-        "color_palette",
         "font_picker",
         "header",
         "html",
@@ -88,16 +88,16 @@
       "then": { "$ref": "#/definitions/color_background" }
     },
     {
+      "if": { "required": ["type"], "properties": { "type": { "const": "color_palette" } } },
+      "then": { "$ref": "#/definitions/color_palette" }
+    },
+    {
       "if": { "required": ["type"], "properties": { "type": { "const": "color_scheme" } } },
       "then": { "$ref": "#/definitions/color_scheme" }
     },
     {
       "if": { "required": ["type"], "properties": { "type": { "const": "color_scheme_group" } } },
       "then": { "$ref": "#/definitions/color_scheme_group" }
-    },
-    {
-      "if": { "required": ["type"], "properties": { "type": { "const": "color_palette" } } },
-      "then": { "$ref": "#/definitions/color_palette" }
     },
     {
       "if": { "required": ["type"], "properties": { "type": { "const": "font_picker" } } },
@@ -344,6 +344,26 @@
       "additionalProperties": false
     },
 
+    "color_palette": {
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
+      "properties": {
+        "type": {
+          "const": "color_palette",
+          "description": "A setting of type color_palette outputs a picker with all of the available theme palette colors.",
+          "markdownDescription": "A setting of type `color_palette` outputs a picker with all of the available theme palette colors.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/settings/input-settings#color_palette)"
+        },
+        "default": { "type": "object", "additionalProperties": { "type": "string" } },
+        "label": true,
+        "info": true,
+        "id": true,
+        "visible_if": true
+      },
+      "additionalProperties": false
+    },
+
     "color_scheme": {
       "allOf": [
         { "$ref": "#/definitions/inputSettingsStandardAttributes" },
@@ -469,26 +489,6 @@
         "id": true
       },
       "required": ["definition", "role"],
-      "additionalProperties": false
-    },
-
-    "color_palette": {
-      "allOf": [
-        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
-        { "$ref": "#/definitions/conditionalSetting" }
-      ],
-      "properties": {
-        "type": {
-          "const": "color_palette",
-          "description": "A setting of type color_palette outputs a picker with all of the available theme palette colors.",
-          "markdownDescription": "A setting of type `color_palette` outputs a picker with all of the available theme palette colors.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/settings/input-settings#color_palette)"
-        },
-        "default": { "type": "object", "additionalProperties": { "type": "string" } },
-        "label": true,
-        "info": true,
-        "id": true,
-        "visible_if": true
-      },
       "additionalProperties": false
     },
 

--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -16,6 +16,7 @@
         "color_background",
         "color_scheme",
         "color_scheme_group",
+        "color_palette",
         "font_picker",
         "header",
         "html",
@@ -93,6 +94,10 @@
     {
       "if": { "required": ["type"], "properties": { "type": { "const": "color_scheme_group" } } },
       "then": { "$ref": "#/definitions/color_scheme_group" }
+    },
+    {
+      "if": { "required": ["type"], "properties": { "type": { "const": "color_palette" } } },
+      "then": { "$ref": "#/definitions/color_palette" }
     },
     {
       "if": { "required": ["type"], "properties": { "type": { "const": "font_picker" } } },
@@ -464,6 +469,26 @@
         "id": true
       },
       "required": ["definition", "role"],
+      "additionalProperties": false
+    },
+
+    "color_palette": {
+      "allOf": [
+        { "$ref": "#/definitions/inputSettingsStandardAttributes" },
+        { "$ref": "#/definitions/conditionalSetting" }
+      ],
+      "properties": {
+        "type": {
+          "const": "color_palette",
+          "description": "A setting of type color_palette outputs a set of named color values.",
+          "markdownDescription": "A setting of type `color_palette` outputs a set of named color values.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/settings/input-settings#color_palette)"
+        },
+        "default": { "type": "object", "additionalProperties": { "type": "string" } },
+        "label": true,
+        "info": true,
+        "id": true,
+        "visible_if": true
+      },
       "additionalProperties": false
     },
 

--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -480,8 +480,8 @@
       "properties": {
         "type": {
           "const": "color_palette",
-          "description": "A setting of type color_palette outputs a set of named color values.",
-          "markdownDescription": "A setting of type `color_palette` outputs a set of named color values.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/settings/input-settings#color_palette)"
+          "description": "A setting of type color_palette outputs a picker with all of the available theme palette colors.",
+          "markdownDescription": "A setting of type `color_palette` outputs a picker with all of the available theme palette colors.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/settings/input-settings#color_palette)"
         },
         "default": { "type": "object", "additionalProperties": { "type": "string" } },
         "label": true,

--- a/tests/fixtures/theme-settings-all-settings.json
+++ b/tests/fixtures/theme-settings-all-settings.json
@@ -118,12 +118,6 @@
         "default": "linear-gradient(#ffffff, #000000)"
       },
       {
-        "type": "color_scheme",
-        "id": "color_scheme",
-        "default": "scheme_1",
-        "label": "Color Scheme"
-      },
-      {
         "type": "color_palette",
         "id": "color_palette",
         "default": {
@@ -131,6 +125,12 @@
           "foreground": "#000000"
         },
         "label": "Color Palette"
+      },
+      {
+        "type": "color_scheme",
+        "id": "color_scheme",
+        "default": "scheme_1",
+        "label": "Color Scheme"
       },
       {
         "type": "color_scheme_group",

--- a/tests/fixtures/theme-settings-all-settings.json
+++ b/tests/fixtures/theme-settings-all-settings.json
@@ -124,6 +124,15 @@
         "label": "Color Scheme"
       },
       {
+        "type": "color_palette",
+        "id": "color_palette",
+        "default": {
+          "background": "#ffffff",
+          "foreground": "#000000"
+        },
+        "label": "Color Palette"
+      },
+      {
         "type": "color_scheme_group",
         "id": "color_schemes",
         "definition": [

--- a/tests/test-constants.ts
+++ b/tests/test-constants.ts
@@ -21,6 +21,7 @@ export const INPUT_SETTING_TYPES = [
   'collection_list',
   'collection',
   'color_background',
+  'color_palette',
   'color_scheme_group',
   'color_scheme',
   'color',


### PR DESCRIPTION
Add color_palette to the accepted theme settings types. Update test files as needed.

- `tests/test-constants.ts` — add `color_palette` to `INPUT_SETTING_TYPES`
- `tests/fixtures/theme-settings-all-settings.json` — add fixture entry to validate the schema definition