### PR TITLE
Drop Node 18 and Node 20 from test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [22.x, 24.x]
 
     name: OS ${{ matrix.os }} / NodeJS ${{ matrix.node-version }}
 


### PR DESCRIPTION
Node 18 hit end of life in April 2025 and Node 20 did the same in April of 2026. We need to bump our supported Node versions in our test suite so that we can bump packages that require security fixes.

For example:

- https://github.com/Shopify/theme-liquid-docs/pull/1697