### PR TITLE
add placeholder support for color input

### DIFF
--- a/schemas/theme/setting.json
+++ b/schemas/theme/setting.json
@@ -318,6 +318,10 @@
           "type": "boolean",
           "description": "A boolean value that determines whether the color picker should include an alpha slider. The default value is true.",
           "markdownDescription": "A boolean value that determines whether the color picker should include an alpha slider. The default value is true.\n\n---\n\n[Shopify reference](https://shopify.dev/docs/themes/architecture/settings/input-settings#color)"
+        },
+        "placeholder": {
+          "type": "string",
+          "description": "A placeholder value for the input."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Update `color` input to support `placeholder` attribute. Part of https://github.com/shop/issues-merchant-workflows/issues/1706

Using same approach and language as other `placeholder` attributes.