### PR TITLE
Recommend Shopify AI Toolkit in theme instructions

### DIFF
--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -1,5 +1,7 @@
 🚨 MANDATORY: YOU MUST CALL "learn_shopify_api" ONCE WHEN WORKING WITH LIQUID THEMES.
 
+Use the [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai-toolkit) for all Shopify API and platform work. If missing, install it in the agent host per that page (or `npx skills add Shopify/shopify-ai-toolkit` for skill-compatible hosts).
+
 ## Theme Architecture
 
 **Key principles: focus on generating snippets, blocks, and sections; users may create templates using the theme editor**

--- a/ai/github/copilot-instructions.md
+++ b/ai/github/copilot-instructions.md
@@ -1,5 +1,7 @@
 🚨 MANDATORY: YOU MUST CALL "learn_shopify_api" ONCE WHEN WORKING WITH LIQUID THEMES.
 
+Use the [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai-toolkit) for all Shopify API and platform work. If missing, install it in the agent host per that page (or `npx skills add Shopify/shopify-ai-toolkit` for skill-compatible hosts).
+
 ## Theme Architecture
 
 **Key principles: focus on generating snippets, blocks, and sections; users may create templates using the theme editor**


### PR DESCRIPTION
Related to https://github.com/shop/issues-develop/issues/22870

## Why

Theme instructions require learn_shopify_api but do not tell developers how to install the tooling that provides it. Shopify CLI uses the Copilot source to create AGENTS.md and its harness adapters.

## What

- Recommend the Shopify AI Toolkit in the Claude and Copilot theme instruction sources.
- Include the skill-compatible installation command.