### PR TITLE
Use ubuntu-latest runner for shopify.dev preview automation

### DIFF
--- a/.github/workflows/shopify-dev-preview-automation.yml
+++ b/.github/workflows/shopify-dev-preview-automation.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   dispatch-liquid-json-schemas-sync:
     name: Dispatch Liquid JSON schemas sync
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Create GitHub App Token (Shop org - world)


### PR DESCRIPTION
### What are you trying to accomplish?

the last time `.github/workflows/shopify-dev-preview-automation.yml` ran successfully was on the `ubuntu-latest` runner back in March

since then, there have been no successful runs. it times out after 24h waiting for an agent. this is happening on https://github.com/Shopify/theme-liquid-docs/pull/1831

### What approach did you use?

switch it back to the github hosted runner