### PR TITLE
Update localization.market summary to clarify multi-market resolution

### DIFF
--- a/data/objects.json
+++ b/data/objects.json
@@ -8646,7 +8646,7 @@
             "array_value": ""
           }
         ],
-        "summary": "The currently selected market on the storefront.",
+        "summary": "The market that applies to the buyer's country. In cases where multiple markets match, this returns the most narrowly scoped country region market.",
         "name": "market"
       },
       {


### PR DESCRIPTION
## Summary
- Updates `localization.market` summary to clarify that when multiple markets match, the most narrowly scoped country region market is returned
- Aligns Liquid docs with the same wording used in the Storefront, Admin, and Functions API PRs

**Related PRs:**
- Storefront API — shop/world#997165
- Admin API — shop/world#991598
- Functions API — shop/world#991698
- Checkout UI extensions — [Shopify/ui-extensions#4618](https://github.com/Shopify/ui-extensions/pull/4618)

## Changes
- `localization.market` summary: "The currently selected market on the storefront." → "The market that applies to the buyer's country. In cases where multiple markets match, this returns the most narrowly scoped country region market."

🤖 Generated with [Claude Code](https://claude.com/claude-code)